### PR TITLE
Small change to utils.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ lr:
 
 I can test out all of these learning rates at the same time by running:
 
-`CUDA_VISIBLE_DEVICES=0,1 python train.py config.yaml --self_host=2 resnet_cifar`
+`CUDA_VISIBLE_DEVICES=0,1 python train.py --config=config.yaml --self_host=2 resnet_cifar`
 
 Ray will handle scheduling the jobs across all available resources.
 

--- a/skeletor/utils.py
+++ b/skeletor/utils.py
@@ -3,14 +3,13 @@ import collections
 import hashlib
 import numpy as np
 import os
+import shutil
 import sys
 import time
 
 TOTAL_BAR_LENGTH = 65.
 
-_, term_width = os.popen('stty size', 'r').read().split()
-term_width = int(term_width)
-
+term_width = shutil.get_terminal_size().columns
 
 def _next_seeds(n):
     # deterministically generate seeds for envs


### PR DESCRIPTION
The line 
`_, term_width = os.popen('stty size', 'r').read().split()`
was crashing with jupyter notebooks because it returns an empty list. Using 

`shutil.get_terminal_size().columns` works in both scenarios.